### PR TITLE
Fix tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,13 @@ skip_missing_interpreters = true
 
 [testenv]
 usedevelop = True
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
+passenv =
+    TOXENV
+    CI
+    TRAVIS
+    TRAVIS_*
+    CODECOV_*
+    GITHUB_*
 setenv =
     PYTHONFAULTHANDLER = 1
 extras =


### PR DESCRIPTION
Fixes the following build error:

```
tox.tox_env.errors.Fail: pass_env values cannot contain whitespace, use comma to have multiple values in a single line
```